### PR TITLE
Add unit test for row clearing

### DIFF
--- a/src/test/java/GameEngine.java
+++ b/src/test/java/GameEngine.java
@@ -1,0 +1,30 @@
+public class GameEngine {
+    protected int mWidth, mHeight;
+    protected java.awt.Color black = java.awt.Color.BLACK;
+    protected java.awt.Color cyan = java.awt.Color.CYAN;
+    protected java.awt.Color blue = java.awt.Color.BLUE;
+    protected java.awt.Color orange = java.awt.Color.ORANGE;
+    protected java.awt.Color yellow = java.awt.Color.YELLOW;
+    protected java.awt.Color green = java.awt.Color.GREEN;
+    protected java.awt.Color pink = java.awt.Color.PINK;
+    protected java.awt.Color red = java.awt.Color.RED;
+    protected java.awt.Color white = java.awt.Color.WHITE;
+
+    public static <T extends GameEngine> void createGame(T game, int fps) {}
+
+    public void setWindowSize(int w, int h) {
+        this.mWidth = w;
+        this.mHeight = h;
+    }
+
+    public void clearBoard() {}
+    public void changeBackgroundColor(java.awt.Color c) {}
+    public void clearBackground(int w, int h) {}
+    public void drawSolidRectangle(int x, int y, int w, int h) {}
+    public void drawBoldText(int x, int y, String text, int size) {}
+    public void drawText(int x, int y, String text, int size) {}
+    public void changeColor(int r, int g, int b) {}
+    public void changeColor(java.awt.Color c) {}
+    public int rand(int max) { return 0; }
+    public void paintComponent() {}
+}

--- a/src/test/java/TetrisTest.java
+++ b/src/test/java/TetrisTest.java
@@ -1,0 +1,19 @@
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+public class TetrisTest {
+    @Test
+    public void testRowClearedAndScoreIncreased() {
+        Tetris t = new Tetris();
+        // fill top row completely
+        for (int x = 0; x < t.WIDTH; x++) {
+            t.grid[x][0] = 1;
+        }
+        int initialScore = t.playerScore;
+        t.checkCompletedRows();
+        for (int x = 0; x < t.WIDTH; x++) {
+            assertEquals("Row should be cleared", 0, t.grid[x][0]);
+        }
+        assertTrue("Score should increase", t.playerScore > initialScore);
+    }
+}


### PR DESCRIPTION
## Summary
- add a minimal `GameEngine` stub for testing
- add `TetrisTest` verifying that a filled row is cleared and the score increases

## Testing
- `javac -d . -cp /opt/gradle/lib/junit-4.13.2.jar:/opt/gradle/lib/hamcrest-core-1.3.jar src/test/java/GameEngine.java Tetris.java src/test/java/TetrisTest.java && java -cp .:/opt/gradle/lib/junit-4.13.2.jar:/opt/gradle/lib/hamcrest-core-1.3.jar org.junit.runner.JUnitCore TetrisTest`

------
https://chatgpt.com/codex/tasks/task_e_68403d2e2e5083268e54a1fbf69157e9